### PR TITLE
Set a default seed for reproducibility

### DIFF
--- a/erv.gemspec
+++ b/erv.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'dotenv', '~> 2.5'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'minitest', '~> 5.11'

--- a/lib/erv/distribution.rb
+++ b/lib/erv/distribution.rb
@@ -1,6 +1,8 @@
 module ERV
 
   class Distribution
+
+    DEFAULT_SEED = 12345
     def initialize(opts={})
       # use provided RNG or create a new one
       if opts[:rng]
@@ -8,7 +10,7 @@ module ERV
       elsif opts[:seed]
         @rng = Random.new(opts[:seed])
       else
-        @rng = Random.new
+        @rng = Random.new(DEFAULT_SEED)
       end
     end
   end

--- a/lib/erv/mixture_distribution.rb
+++ b/lib/erv/mixture_distribution.rb
@@ -10,6 +10,9 @@ require 'erv/uniform_distribution'
 module ERV
 
   class MixtureDistribution
+
+    DEFAULT_SEED = 12345
+    
     def initialize(confs, opts={})
       raise ArgumentError, "Please, provide at least 2 distributions!" if confs.count < 2
 
@@ -42,6 +45,7 @@ module ERV
       end
 
       seed = opts[:seed]
+      seed = DEFAULT_SEED if seed.nil?
       @mixture_sampler = (seed ? Random.new(seed) : Random.new)
     end
 


### PR DESCRIPTION
Both distribution.rb and mixture_distribution.rb define and set a default seed.